### PR TITLE
Add: support for in memory image stream to darknet detector

### DIFF
--- a/darknet.d.ts
+++ b/darknet.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 export declare class Darknet {
     darknet: any;
     meta: any;
@@ -8,27 +9,48 @@ export declare class Darknet {
      * @param config
      */
     constructor(config: IDarknetConfig);
-    private getArrayFromBuffer(buffer, length, type);
-    private bufferToDetections(buffer, length);
-    private _detectSync(net, meta, image, thresh?, hier_thresh?, nms?);
+    private getArrayFromBuffer;
+    private bufferToDetections;
+    private _detectSync;
+    private _detectAsync;
     /**
      * Synchronously detect objects in an image.
      * @param image the destination of the image to be detected
      * @param config optional configuration (threshold, etc.)
      */
-    detect(image: string, config?: IConfig): Detection[];
+    detect(image: string | IBufferImage, config?: IConfig): Detection[];
+    getImageFromPath(path: string): any;
+    getImageFromPathAsync(path: String): Promise<{}>;
+    imageToRGBBuffer(image: any): Buffer;
+    private rgbToDarknet;
+    RGBBufferToImage(buffer: Buffer, w: number, h: number, c: number): any;
+    /**
+     * Transform an RGB buffer to a darknet encoded image
+     * @param buffer - rgb buffer
+     * @param w - width
+     * @param h - height
+     * @param c - channels
+     * @returns Promise<IMAGE>
+     */
+    RGBBufferToImageAsync(buffer: Buffer, w: number, h: number, c: number): Promise<any>;
     /**
      * Asynchronously detect objects in an image.
      * @param image
      * @param config
      * @returns A promise
      */
-    detectAsync(image: string, config?: IConfig): Promise<Detection[]>;
+    detectAsync(image: string | IBufferImage, config?: IConfig): Promise<Detection[]>;
 }
 export interface IConfig {
     thresh?: number;
     hier_thresh?: number;
     nms?: number;
+}
+export interface IBufferImage {
+    b: Buffer;
+    w: number;
+    h: number;
+    c: number;
 }
 export declare type IClasses = string[];
 export interface IDarknetConfig {

--- a/darknet.js
+++ b/darknet.js
@@ -1,4 +1,39 @@
 "use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 var ffi = require("ffi");
 var ref = require("ref");
@@ -56,6 +91,7 @@ var Darknet = /** @class */ (function () {
         this.meta.classes = this.names.length;
         this.meta.names = this.names.join('\n');
         this.darknet = ffi.Library(library, {
+            'float_to_image': [IMAGE, ['int', 'int', 'int', float_pointer]],
             'load_image_color': [IMAGE, ['string', 'int', 'int']],
             'network_predict_image': [float_pointer, ['pointer', IMAGE]],
             'get_network_boxes': [detection_pointer, ['pointer', 'int', 'int', 'float', 'float', int_pointer, 'int', int_pointer]],
@@ -104,16 +140,44 @@ var Darknet = /** @class */ (function () {
             hier_thresh = 0.5;
         if (!nms)
             nms = 0.45;
-        var _image = this.darknet.load_image_color(image, 0, 0);
-        this.darknet.network_predict_image(net, _image);
+        this.darknet.network_predict_image(net, image);
         var pnum = ref.alloc('int');
-        var dets = this.darknet.get_network_boxes(net, _image.w, _image.h, thresh, hier_thresh, ref.NULL_POINTER, 0, pnum);
+        var dets = this.darknet.get_network_boxes(net, image.w, image.h, thresh, hier_thresh, ref.NULL_POINTER, 0, pnum);
         var num = pnum.deref();
         this.darknet.do_nms_obj(dets, num, meta.classes, nms);
         var detections = this.bufferToDetections(dets, num);
-        this.darknet.free_image(_image);
         this.darknet.free_detections(dets, num);
         return detections;
+    };
+    Darknet.prototype._detectAsync = function (net, meta, image, thresh, hier_thresh, nms) {
+        return __awaiter(this, void 0, void 0, function () {
+            var pnum, dets, num, detections;
+            var _this = this;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, new Promise(function (res, rej) {
+                            return _this.darknet.network_predict_image.async(net, image, function (e) { return e ? rej(e) : res(); });
+                        })];
+                    case 1:
+                        _a.sent();
+                        pnum = ref.alloc('int');
+                        return [4 /*yield*/, new Promise(function (res, rej) {
+                                return _this.darknet.get_network_boxes.async(net, image.w, image.h, thresh, hier_thresh, ref.NULL_POINTER, 0, pnum, function (err, dets) { return err ? rej(err) : res(dets); });
+                            })];
+                    case 2:
+                        dets = _a.sent();
+                        num = pnum.deref();
+                        return [4 /*yield*/, new Promise(function (res, rej) {
+                                return _this.darknet.do_nms_obj.async(dets, num, meta.classes, nms, function (e) { return e ? rej(e) : res(); });
+                            })];
+                    case 3:
+                        _a.sent();
+                        detections = this.bufferToDetections(dets, num);
+                        this.darknet.free_detections(dets, num);
+                        return [2 /*return*/, detections];
+                }
+            });
+        });
     };
     /**
      * Synchronously detect objects in an image.
@@ -123,7 +187,86 @@ var Darknet = /** @class */ (function () {
     Darknet.prototype.detect = function (image, config) {
         if (!config)
             config = {};
-        return this._detectSync(this.net, this.meta, image, config.thresh, config.hier_thresh, config.nms);
+        var darkNetLoadedImage = typeof image === 'string';
+        var imageData = typeof image === 'string' ?
+            this.getImageFromPath(image) :
+            this.RGBBufferToImage(image.b, image.w, image.h, image.c);
+        var detection = this._detectSync(this.net, this.meta, imageData, config.thresh, config.hier_thresh, config.nms);
+        if (darkNetLoadedImage) {
+            // memory is owned by the darknet lib
+            this.darknet.free_image(imageData);
+        }
+        else {
+            // memory is owned by JS and will GC eventually
+        }
+        return detection;
+    };
+    Darknet.prototype.getImageFromPath = function (path) {
+        return this.darknet.load_image_color(path, 0, 0);
+    };
+    Darknet.prototype.getImageFromPathAsync = function (path) {
+        return __awaiter(this, void 0, void 0, function () {
+            var _this = this;
+            return __generator(this, function (_a) {
+                return [2 /*return*/, new Promise(function (res, rej) {
+                        return _this.darknet.load_image_color.async(path, 0, 0, function (e, image) { return e ? rej(e) : res(image); });
+                    })];
+            });
+        });
+    };
+    Darknet.prototype.imageToRGBBuffer = function (image) {
+        var w = image.w;
+        var h = image.h;
+        var c = image.c;
+        var imageElements = w * h * c;
+        var imageData = new Float32Array(image.data.reinterpret(imageElements * Float32Array.BYTES_PER_ELEMENT, 0).buffer, 0, imageElements);
+        var rgbBuffer = Buffer.allocUnsafe(imageData.length);
+        var step = c * w;
+        var i, k, j;
+        for (i = 0; i < h; ++i) {
+            for (k = 0; k < c; ++k) {
+                for (j = 0; j < w; ++j) {
+                    rgbBuffer[i * step + j * c + k] = imageData[k * w * h + i * w + j] * 255;
+                }
+            }
+        }
+        return rgbBuffer;
+    };
+    Darknet.prototype.rgbToDarknet = function (buffer, w, h, c) {
+        var imageElements = w * h * c;
+        var floatBuff = new Float32Array(imageElements);
+        var step = w * c;
+        var i, k, j;
+        for (i = 0; i < h; ++i) {
+            for (k = 0; k < c; ++k) {
+                for (j = 0; j < w; ++j) {
+                    floatBuff[k * w * h + i * w + j] = buffer[i * step + j * c + k] / 255;
+                }
+            }
+        }
+        return floatBuff;
+    };
+    Darknet.prototype.RGBBufferToImage = function (buffer, w, h, c) {
+        var floatBuff = this.rgbToDarknet(buffer, w, h, c);
+        return this.darknet.float_to_image(w, h, c, new Uint8Array(floatBuff.buffer, 0, floatBuff.length * Float32Array.BYTES_PER_ELEMENT));
+    };
+    /**
+     * Transform an RGB buffer to a darknet encoded image
+     * @param buffer - rgb buffer
+     * @param w - width
+     * @param h - height
+     * @param c - channels
+     * @returns Promise<IMAGE>
+     */
+    Darknet.prototype.RGBBufferToImageAsync = function (buffer, w, h, c) {
+        return __awaiter(this, void 0, void 0, function () {
+            var floatBuff;
+            var _this = this;
+            return __generator(this, function (_a) {
+                floatBuff = this.rgbToDarknet(buffer, w, h, c);
+                return [2 /*return*/, new Promise(function (res, rej) { return _this.darknet.float_to_image.async(w, h, c, new Uint8Array(floatBuff.buffer, 0, floatBuff.length * Float32Array.BYTES_PER_ELEMENT), function (e, image) { return e ? rej(e) : res(image); }); })];
+            });
+        });
     };
     /**
      * Asynchronously detect objects in an image.
@@ -132,26 +275,43 @@ var Darknet = /** @class */ (function () {
      * @returns A promise
      */
     Darknet.prototype.detectAsync = function (image, config) {
-        var _this = this;
-        if (!config)
-            config = {};
-        var thresh = (config.thresh) ? config.thresh : 0.5;
-        var hier_thresh = (config.hier_thresh) ? config.hier_thresh : 0.5;
-        var nms = (config.nms) ? config.nms : 0.5;
-        return new Promise(function (resolve, reject) {
-            _this.darknet.load_image_color.async(image, 0, 0, function (err, _image) {
-                _this.darknet.network_predict_image.async(_this.net, _image, function () {
-                    var pnum = ref.alloc('int');
-                    _this.darknet.get_network_boxes.async(_this.net, _image.w, _image.h, thresh, hier_thresh, ref.NULL_POINTER, 0, pnum, function (err, dets) {
-                        var num = pnum.deref();
-                        _this.darknet.do_nms_obj.async(dets, num, _this.meta.classes, nms, function () {
-                            var detections = _this.bufferToDetections(dets, num);
-                            _this.darknet.free_image(_image);
-                            _this.darknet.free_detections(dets, num);
-                            resolve(detections);
-                        });
-                    });
-                });
+        return __awaiter(this, void 0, void 0, function () {
+            var thresh, hier_thresh, nms, darkNetLoadedImage, imageData, _a, detection;
+            var _this = this;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0:
+                        if (!config)
+                            config = {};
+                        thresh = (config.thresh) ? config.thresh : 0.5;
+                        hier_thresh = (config.hier_thresh) ? config.hier_thresh : 0.5;
+                        nms = (config.nms) ? config.nms : 0.5;
+                        darkNetLoadedImage = typeof image === 'string';
+                        if (!(typeof image === 'string')) return [3 /*break*/, 2];
+                        return [4 /*yield*/, this.getImageFromPathAsync(image)];
+                    case 1:
+                        _a = _b.sent();
+                        return [3 /*break*/, 4];
+                    case 2: return [4 /*yield*/, this.RGBBufferToImageAsync(image.b, image.w, image.h, image.c)];
+                    case 3:
+                        _a = _b.sent();
+                        _b.label = 4;
+                    case 4:
+                        imageData = _a;
+                        return [4 /*yield*/, this._detectAsync(this.net, this.meta, imageData, thresh, hier_thresh, nms)];
+                    case 5:
+                        detection = _b.sent();
+                        if (!darkNetLoadedImage) return [3 /*break*/, 7];
+                        // memory is owned by the darknet lib
+                        return [4 /*yield*/, new Promise(function (res, rej) {
+                                return _this.darknet.free_image.async(imageData, function (e) { return e ? rej(e) : res(); });
+                            })];
+                    case 6:
+                        // memory is owned by the darknet lib
+                        _b.sent();
+                        return [3 /*break*/, 7];
+                    case 7: return [2 /*return*/, detection];
+                }
             });
         });
     };


### PR DESCRIPTION
Added support to stream data to darknet from memory so it's easier to process video.

Here's a usecase:
```js
const fs = require('fs');
const cv = require('opencv4nodejs');
const { Darknet } = require('.');

const darknet = new Darknet({
  weights: 'yolov3.weights',
  config: 'cfg/yolov3.cfg',
  names: fs.readFileSync('data/coco.names').toString().trim().split('\n')
});

const cap = new cv.VideoCapture('video.mp4');

let frame;
let index = 0;
do {
  frame = cap.read().cvtColor(cv.COLOR_BGR2RGB);
  console.log('frame', index++); 
  console.log(darknet.detect({
    b: frame.getData(),
    w: frame.cols,
    h: frame.rows,
    c: frame.channels
  }));
} while(!frame.empty);

``` 

- Kept backwards compatibility
- Introduced `getImageFromPath`/`imageToRGBBuffer`/`RGBBufferToImage` (useful for debugging)