### PR TITLE
Update: refactored install script and added macOS support

### DIFF
--- a/install-script.sh
+++ b/install-script.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+if [ ! -f libdarknet.so ]; then
+
+    if [ ! -d darknet ]; then
+        git clone https://github.com/pjreddie/darknet;
+
+        if [ $? -ne 0 ]; then
+            echo "Could not clone darknet repo";
+            exit 1;
+        fi
+    fi
+
+    # dive in the darknet folder and make
+    cd darknet && make
+
+    if [ $? -ne 0 ]; then
+        echo "Could not compile darknet";
+        exit 2;
+    fi
+
+    # copy lib
+    cp libdarknet* ..
+
+    # dive out
+    cd ..
+
+    # if macos make .dylib symlink
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        ln -s libdarknet.so libdarknet.dylib
+    fi
+
+else
+    echo "Already built darknet"
+fi

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/bennetthardwick/darknet.js",
   "scripts": {
     "test": "echo \"AIN'T NOBODY GOT TIME FOR THAT!\" && exit 1",
-    "install": "git clone https://github.com/pjreddie/darknet && cd darknet && make && cp libdarknet* .. || echo \"Already built darknet\"",
+    "install": "./install-script.sh",
     "prepare": "tsc"
   },
   "keywords": [


### PR DESCRIPTION
Refactored the install script so it's easier to work with and added support for macOS.
`node-ffi` looks for a `.dylib` but darknet only outputs `.so`, so we create a symlink from the `.so` to `.dylib`