### PR TITLE
Add: DARKNET_BUILD_WITH_GPU & DARKNET_BUILD_WITH_CUDNN

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ darknet.detectAsync('/image/of/a/dog.jpg')
 Unfortunately only Promises are supported at this time, but support for callbacks will be coming soon.
 
 ## Activating Turbo Mode
-If you want to use CUDA, you'll have to enable it yourself. To do this, navigate to the directory where darknet.js is installed (`node_modules/darknet`), and edit the makefile inside the darknet repo, `darknet/Makefile` to say `GPU=1`. With this enabled, issue the command `make && cp libdarknet* ..` to compile darknet library and copy it to the root of darknet.js. After doing this, Darknet.js should work with your CUDA enabled GPU.
+If you want to use CUDA, you'll have to `export DARKNET_BUILD_WITH_GPU=1` before installing this package.
+You can also enable CUDNN if installed by adding `export DARKNET_BUILD_WITH_CUDNN=1`.
+After doing this, Darknet.js should work with your CUDA enabled GPU.
 
 ## Built-With
 - [Node FFI](https://github.com/node-ffi/node-ffi)

--- a/install-script.sh
+++ b/install-script.sh
@@ -12,7 +12,25 @@ if [ ! -f libdarknet.so ]; then
     fi
 
     # dive in the darknet folder and make
-    cd darknet && make
+    cd darknet
+
+    # look for exported variables for GPU and CUDNN
+    GPU="${DARKNET_BUILD_WITH_GPU:-0}";
+    CUDNN="${DARKNET_BUILD_WITH_CUDNN:-0}";
+
+    case "$GPU" in
+        1|0);;
+        *) echo "Interpreting DARKNET_BUILD_WITH_GPU=$GPU as 1"; GPU=0;;
+    esac
+    case "$CUDNN" in
+        1|0);;
+        *) echo "Interpreting DARKNET_BUILD_WITH_CUDNN=$CUDNN as 1"; CUDNN=0;;
+    esac
+
+    sed -i -e "s/GPU=[01]/GPU=${GPU}/g" ./Makefile
+    sed -i -e "s/CUDNN=[01]/CUDNN=${CUDNN}/g" ./Makefile
+
+    make
 
     if [ $? -ne 0 ]; then
         echo "Could not compile darknet";

--- a/install-script.sh
+++ b/install-script.sh
@@ -20,11 +20,11 @@ if [ ! -f libdarknet.so ]; then
 
     case "$GPU" in
         1|0);;
-        *) echo "Interpreting DARKNET_BUILD_WITH_GPU=$GPU as 1"; GPU=0;;
+        *) echo "Interpreting DARKNET_BUILD_WITH_GPU=$GPU as 0"; GPU=0;;
     esac
     case "$CUDNN" in
         1|0);;
-        *) echo "Interpreting DARKNET_BUILD_WITH_CUDNN=$CUDNN as 1"; CUDNN=0;;
+        *) echo "Interpreting DARKNET_BUILD_WITH_CUDNN=$CUDNN as 0"; CUDNN=0;;
     esac
 
     sed -i -e "s/GPU=[01]/GPU=${GPU}/g" ./Makefile

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "test": "echo \"AIN'T NOBODY GOT TIME FOR THAT!\" && exit 1",
     "install": "./install-script.sh",
-    "prepare": "tsc"
+    "prepare": "tsc",
+    "clean": "rm libdarknet.*"
   },
   "keywords": [
     "darknet",


### PR DESCRIPTION
Added external variable check for: 
- `DARKNET_BUILD_WITH_GPU`
- `DARKNET_BUILD_WITH_CUDNN`

They only accept 1 or 0 and directly modify the `makefile` before `make` with the requested options